### PR TITLE
Implement hierarchical bounds culling system

### DIFF
--- a/Assets/HierarchicalCulling/Editor/HierarchicalBoundsGizmos.cs
+++ b/Assets/HierarchicalCulling/Editor/HierarchicalBoundsGizmos.cs
@@ -1,0 +1,27 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Optim.HierarchicalCulling.Editor
+{
+    [InitializeOnLoad]
+    internal static class HierarchicalBoundsGizmos
+    {
+        static HierarchicalBoundsGizmos()
+        {
+            SceneView.duringSceneGui += OnSceneGUI;
+        }
+
+        private static void OnSceneGUI(SceneView view)
+        {
+            if (!SessionState.GetBool("HB_GizmosVisible", true))
+                return;
+
+            foreach (var hb in GameObject.FindObjectsOfType<HierarchicalBounds>())
+            {
+                Handles.color = hb.Rendered ? Color.green : Color.red;
+                Handles.DrawWireCube(hb.Bounds.center, hb.Bounds.size);
+            }
+        }
+    }
+}
+

--- a/Assets/HierarchicalCulling/Editor/HierarchicalBoundsToolbar.cs
+++ b/Assets/HierarchicalCulling/Editor/HierarchicalBoundsToolbar.cs
@@ -1,0 +1,28 @@
+using UnityEditor;
+using UnityEditor.Overlays;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Optim.HierarchicalCulling.Editor
+{
+#if UNITY_2021_2_OR_NEWER
+    [Overlay(typeof(SceneView), "Hierarchical Bounds", true)]
+    public class HierarchicalBoundsToolbar : Overlay
+    {
+        public override VisualElement CreatePanelContent()
+        {
+            var button = new ToolbarButton(() => HierarchicalBoundsGizmosVisible = !HierarchicalBoundsGizmosVisible)
+            {
+                text = "Toggle Bounds"
+            };
+            return button;
+        }
+
+        private static bool HierarchicalBoundsGizmosVisible
+        {
+            get => SessionState.GetBool("HB_GizmosVisible", true);
+            set => SessionState.SetBool("HB_GizmosVisible", value);
+        }
+    }
+#endif
+}

--- a/Assets/HierarchicalCulling/Editor/HierarchicalBoundsWindow.cs
+++ b/Assets/HierarchicalCulling/Editor/HierarchicalBoundsWindow.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace Optim.HierarchicalCulling.Editor
+{
+    public class HierarchicalBoundsWindow : EditorWindow
+    {
+        private Vector2 scroll;
+        private List<HierarchicalBounds> roots = new List<HierarchicalBounds>();
+
+        [MenuItem("Window/Hierarchical Bounds Viewer")]
+        static void Open()
+        {
+            GetWindow<HierarchicalBoundsWindow>("Hierarchical Bounds");
+        }
+
+        private void OnEnable()
+        {
+            Refresh();
+        }
+
+        private void OnGUI()
+        {
+            if (GUILayout.Button("Refresh"))
+            {
+                Refresh();
+            }
+
+            scroll = EditorGUILayout.BeginScrollView(scroll);
+            foreach (var root in roots)
+            {
+                DrawHierarchy(root, 0);
+            }
+            EditorGUILayout.EndScrollView();
+        }
+
+        private void DrawHierarchy(HierarchicalBounds hb, int indent)
+        {
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.Space(indent * 16);
+            bool enabled = hb.Rendered;
+            bool toggled = EditorGUILayout.ToggleLeft(hb.name, enabled);
+            if (toggled != enabled)
+            {
+                hb.ManualUpdate();
+            }
+            if (GUILayout.Button("Recalc", GUILayout.Width(60)))
+            {
+                hb.RecalculateBounds();
+            }
+            EditorGUILayout.EndHorizontal();
+
+            foreach (var child in hb.Children)
+            {
+                DrawHierarchy(child, indent + 1);
+            }
+        }
+
+        private void Refresh()
+        {
+            roots.Clear();
+            foreach (var hb in GameObject.FindObjectsOfType<HierarchicalBounds>())
+            {
+                if (hb.Parent == null)
+                    roots.Add(hb);
+            }
+        }
+    }
+}
+

--- a/Assets/HierarchicalCulling/Scripts/HierarchicalBounds.cs
+++ b/Assets/HierarchicalCulling/Scripts/HierarchicalBounds.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Optim.HierarchicalCulling
+{
+    /// <summary>
+    /// Hierarchical bounds container that collects renderers from its hierarchy
+    /// and performs view frustum culling.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class HierarchicalBounds : MonoBehaviour
+    {
+        public enum UpdateTiming
+        {
+            FixedUpdate,
+            Update,
+            Manual
+        }
+
+        [Serializable]
+        public class RendererInfo
+        {
+            public Renderer Renderer;
+            public bool OriginalEnabled;
+        }
+
+        [SerializeField]
+        private UpdateTiming updateTiming = UpdateTiming.Update;
+
+        [SerializeField]
+        private float margin = 0f;
+
+        [SerializeField]
+        private bool skipIfSameFixedFrame = true;
+
+        [SerializeField]
+        private bool rendered = true;
+
+        [SerializeField, HideInInspector]
+        private Bounds bounds;
+
+        [SerializeField, HideInInspector]
+        private HierarchicalBounds parent;
+
+        [SerializeField, HideInInspector]
+        private List<HierarchicalBounds> children = new List<HierarchicalBounds>();
+
+        [SerializeField, HideInInspector]
+        private List<RendererInfo> renderers = new List<RendererInfo>();
+
+        private int lastFixedUpdateFrame = -1;
+
+        public Bounds Bounds => bounds;
+        public bool Rendered => rendered;
+        public HierarchicalBounds Parent => parent;
+        public IReadOnlyList<HierarchicalBounds> Children => children;
+        public IReadOnlyList<RendererInfo> ManagedRenderers => renderers;
+
+        public event Action<bool> OnRenderedChanged;
+
+        private void Reset()
+        {
+            RecalculateBounds();
+        }
+
+        private void Awake()
+        {
+            RegisterToParent();
+        }
+
+        private void OnDestroy()
+        {
+            UnregisterFromParent();
+        }
+
+        private void RegisterToParent()
+        {
+            Transform t = transform.parent;
+            while (t != null)
+            {
+                var hb = t.GetComponent<HierarchicalBounds>();
+                if (hb)
+                {
+                    parent = hb;
+                    hb.children.Add(this);
+                    break;
+                }
+                t = t.parent;
+            }
+        }
+
+        private void UnregisterFromParent()
+        {
+            if (parent)
+            {
+                parent.children.Remove(this);
+            }
+        }
+
+        private void Update()
+        {
+            if (updateTiming == UpdateTiming.Update)
+                EvaluateCulling();
+        }
+
+        private void FixedUpdate()
+        {
+            if (updateTiming == UpdateTiming.FixedUpdate)
+            {
+                if (skipIfSameFixedFrame && lastFixedUpdateFrame == Time.frameCount)
+                    return;
+                lastFixedUpdateFrame = Time.frameCount;
+                EvaluateCulling();
+            }
+        }
+
+        /// <summary>
+        /// Manually trigger culling evaluation.
+        /// </summary>
+        public void ManualUpdate()
+        {
+            if (updateTiming == UpdateTiming.Manual)
+                EvaluateCulling();
+        }
+
+        private void EvaluateCulling()
+        {
+            if (Camera.main == null)
+                return;
+            Plane[] planes = GeometryUtility.CalculateFrustumPlanes(Camera.main);
+            bool intersects = GeometryUtility.TestPlanesAABB(planes, bounds);
+            SetRendered(intersects);
+        }
+
+        private void SetRendered(bool value)
+        {
+            if (rendered == value)
+                return;
+            rendered = value;
+
+            foreach (var info in renderers)
+            {
+                if (info.Renderer)
+                {
+                    info.Renderer.enabled = rendered && info.OriginalEnabled;
+                }
+            }
+
+            foreach (var child in children)
+            {
+                child.SetRendered(rendered);
+            }
+
+            OnRenderedChanged?.Invoke(rendered);
+        }
+
+        /// <summary>
+        /// Recalculate bounds and collect renderers.
+        /// </summary>
+        [ContextMenu("Recalculate Bounds")]
+        public void RecalculateBounds()
+        {
+            renderers.Clear();
+            children.Clear();
+            bounds = new Bounds(transform.position, Vector3.zero);
+
+            var childHierarchies = new List<HierarchicalBounds>();
+            GetComponentsInChildren(true, childHierarchies);
+            childHierarchies.Remove(this);
+
+            var childRendererList = new List<Renderer>();
+            GetComponentsInChildren(true, childRendererList);
+
+            foreach (var child in childHierarchies)
+            {
+                childRendererList.RemoveAll(r => r.transform.IsChildOf(child.transform));
+                children.Add(child);
+                child.parent = this;
+            }
+
+            foreach (var r in childRendererList)
+            {
+                if (r.GetComponentInParent<HierarchicalBounds>() != this)
+                    continue;
+                RendererInfo info = new RendererInfo { Renderer = r, OriginalEnabled = r.enabled };
+                renderers.Add(info);
+                if (bounds.size == Vector3.zero)
+                    bounds = r.bounds;
+                else
+                    bounds.Encapsulate(r.bounds);
+            }
+
+            foreach (var child in children)
+            {
+                child.RecalculateBounds();
+                bounds.Encapsulate(child.bounds);
+            }
+
+            bounds.Expand(margin);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `HierarchicalBounds` runtime component to build a hierarchy of bounds and perform frustum checks
- add editor window for inspecting hierarchy and recalculating bounds
- draw bounds in the Scene view with a toolbar overlay to toggle visibility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845351323e48332a51e2b31d57be285