### PR TITLE
Fix sorting in SceneMaterialsWindow

### DIFF
--- a/Assets/MaterialViewer/Editor/SceneMaterialsWindow.cs
+++ b/Assets/MaterialViewer/Editor/SceneMaterialsWindow.cs
@@ -177,8 +177,8 @@ namespace Optim.MaterialViewer.Editor
             var state = new TreeViewState();
             header = new MultiColumnHeader(CreateHeaderState());
             header.canSort = true;
-            header.sortingChanged += treeView?.OnSortingChanged;
             treeView = new MaterialTreeView(state, header, materials);
+            header.sortingChanged += treeView.OnSortingChanged;
             treeView.SelectionChanged += info => selected = info;
             searchField = new SearchField();
         }


### PR DESCRIPTION
## Summary
- fix column header sorting by subscribing after `treeView` is created

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68454c83972c8332a79d416b8f22bcf1