### PR TITLE
Fix button label

### DIFF
--- a/Assets/HierarchicalCulling/Editor/HierarchicalBoundsWindow.cs
+++ b/Assets/HierarchicalCulling/Editor/HierarchicalBoundsWindow.cs
@@ -45,7 +45,7 @@ namespace Optim.HierarchicalCulling.Editor
             {
                 hb.ManualUpdate();
             }
-            if (GUILayout.Button("Recalc", GUILayout.Width(60)))
+            if (GUILayout.Button("Recalculate", GUILayout.Width(60)))
             {
                 hb.RecalculateBounds();
             }


### PR DESCRIPTION
## Summary
- fix the "Recalc" button label in `HierarchicalBoundsWindow` to read "Recalculate"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68454c85920c833291dca83c238a9a36