### PR TITLE
Use NativeArray for planes in intersection checks

### DIFF
--- a/Assets/FrustumIntersection/Scripts/CPUImplementation.cs
+++ b/Assets/FrustumIntersection/Scripts/CPUImplementation.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Unity.Collections;
 using UnityEngine;
 
 namespace Optim.FrustumIntersection
@@ -29,12 +30,13 @@ namespace Optim.FrustumIntersection
 
             var vertices = mesh.vertices;
             var indices = mesh.triangles;
+            var nativePlanes = new NativeArray<Plane>(planes, Allocator.Temp);
             for (int i = 0; i < indices.Length; i += 3)
             {
                 Vector3 v0 = vertices[indices[i]];
                 Vector3 v1 = vertices[indices[i + 1]];
                 Vector3 v2 = vertices[indices[i + 2]];
-                if (checker.Intersects(v0, v1, v2, planes))
+                if (checker.Intersects(v0, v1, v2, nativePlanes))
                 {
                     if (options.CollectIndices)
                     {
@@ -46,6 +48,8 @@ namespace Optim.FrustumIntersection
                     }
                 }
             }
+
+            nativePlanes.Dispose();
 
             if (watch != null)
             {

--- a/Assets/FrustumIntersection/Scripts/DefaultTriangleChecker.cs
+++ b/Assets/FrustumIntersection/Scripts/DefaultTriangleChecker.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Unity.Collections;
 
 namespace Optim.FrustumIntersection
 {
@@ -7,10 +8,11 @@ namespace Optim.FrustumIntersection
     /// </summary>
     public class DefaultTriangleChecker : ITriangleIntersectionChecker
     {
-        public bool Intersects(Vector3 v0, Vector3 v1, Vector3 v2, Plane[] planes)
+        public bool Intersects(Vector3 v0, Vector3 v1, Vector3 v2, NativeArray<Plane> planes)
         {
-            foreach (var p in planes)
+            for (int i = 0; i < planes.Length; ++i)
             {
+                Plane p = planes[i];
                 float d0 = p.GetDistanceToPoint(v0);
                 float d1 = p.GetDistanceToPoint(v1);
                 float d2 = p.GetDistanceToPoint(v2);

--- a/Assets/FrustumIntersection/Scripts/ITriangleIntersectionChecker.cs
+++ b/Assets/FrustumIntersection/Scripts/ITriangleIntersectionChecker.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Unity.Collections;
 
 namespace Optim.FrustumIntersection
 {
@@ -14,6 +15,6 @@ namespace Optim.FrustumIntersection
         /// <param name="v1">Triangle vertex 1.</param>
         /// <param name="v2">Triangle vertex 2.</param>
         /// <param name="planes">Frustum planes.</param>
-        bool Intersects(Vector3 v0, Vector3 v1, Vector3 v2, Plane[] planes);
+        bool Intersects(Vector3 v0, Vector3 v1, Vector3 v2, NativeArray<Plane> planes);
     }
 }

--- a/Assets/FrustumIntersection/Scripts/JobSystemImplementation.cs
+++ b/Assets/FrustumIntersection/Scripts/JobSystemImplementation.cs
@@ -34,7 +34,7 @@ namespace Optim.FrustumIntersection
                 Vector3 v0 = Vertices[Indices[i]];
                 Vector3 v1 = Vertices[Indices[i + 1]];
                 Vector3 v2 = Vertices[Indices[i + 2]];
-                if (Checker.Intersects(v0, v1, v2, Planes.ToArray()))
+                if (Checker.Intersects(v0, v1, v2, Planes))
                 {
                     if (Collect)
                         Results.AddNoResize(index);


### PR DESCRIPTION
## Summary
- change `ITriangleIntersectionChecker.Intersects` to accept `NativeArray<Plane>`
- update `DefaultTriangleChecker` and `CPUImplementation` for the new signature
- pass native planes directly in `JobSystemImplementation.IntersectJob`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849ad5c1f248332be6d59c6cd311a06