### PR TITLE
Ensure GPU shader receives correct index count

### DIFF
--- a/Assets/FrustumIntersection/Scripts/GPUImplementation.cs
+++ b/Assets/FrustumIntersection/Scripts/GPUImplementation.cs
@@ -29,7 +29,8 @@ namespace Optim.FrustumIntersection
 
             var vertices = mesh.vertices;
             var indices = mesh.triangles;
-            int triCount = indices.Length / 3;
+            int indexCount = indices.Length;
+            int triCount = indexCount / 3;
 
             ComputeBuffer vbuf = new ComputeBuffer(vertices.Length, sizeof(float) * 3);
             ComputeBuffer ibuf = new ComputeBuffer(indices.Length, sizeof(int));
@@ -44,6 +45,7 @@ namespace Optim.FrustumIntersection
             shader.SetBuffer(kernel, "_Planes", pbuf);
             shader.SetBuffer(kernel, "_Results", rbuf);
             shader.SetInt("_PlaneCount", planes.Length);
+            shader.SetInt("_IndexCount", indexCount);
 
             uint threadGroupSizeX;
             shader.GetKernelThreadGroupSizes(kernel, out threadGroupSizeX, out _, out _);

--- a/Assets/FrustumIntersection/Shaders/TriangleIntersection.compute
+++ b/Assets/FrustumIntersection/Shaders/TriangleIntersection.compute
@@ -11,13 +11,14 @@ StructuredBuffer<int> _Indices;
 StructuredBuffer<Plane> _Planes;
 RWStructuredBuffer<int> _Results;
 uint _PlaneCount;
+uint _IndexCount;
 
 [numthreads(64,1,1)]
 void CSMain (uint id : SV_DispatchThreadID)
 {
     uint triIndex = id;
     uint i = triIndex * 3;
-    if (i + 2 >= _Indices.Length)
+    if (i + 2 >= _IndexCount)
         return;
 
     float3 v0 = _Vertices[_Indices[i]];


### PR DESCRIPTION
## Summary
- send triangle index count to the compute shader
- add `_IndexCount` uniform in `TriangleIntersection.compute`
- use the new uniform to validate index bounds

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849ad588d148332a274ef05af8ed58f