### PR TITLE
Return per triangle intersection flags

### DIFF
--- a/Assets/FrustumIntersection/Scripts/CPUImplementation.cs
+++ b/Assets/FrustumIntersection/Scripts/CPUImplementation.cs
@@ -30,23 +30,16 @@ namespace Optim.FrustumIntersection
 
             var vertices = mesh.vertices;
             var indices = mesh.triangles;
+            int triCount = indices.Length / 3;
+            result.Intersections = new bool[triCount];
             var nativePlanes = new NativeArray<Plane>(planes, Allocator.Temp);
             for (int i = 0; i < indices.Length; i += 3)
             {
                 Vector3 v0 = vertices[indices[i]];
                 Vector3 v1 = vertices[indices[i + 1]];
                 Vector3 v2 = vertices[indices[i + 2]];
-                if (checker.Intersects(v0, v1, v2, nativePlanes))
-                {
-                    if (options.CollectIndices)
-                    {
-                        result.IntersectedIndices.Add(i / 3);
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
+                bool inside = checker.Intersects(v0, v1, v2, nativePlanes);
+                result.Intersections[i / 3] = inside;
             }
 
             nativePlanes.Dispose();

--- a/Assets/FrustumIntersection/Scripts/FrustumIntersectionTypes.cs
+++ b/Assets/FrustumIntersection/Scripts/FrustumIntersectionTypes.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace Optim.FrustumIntersection
@@ -23,11 +22,6 @@ namespace Optim.FrustumIntersection
         public FrustumType Frustum = FrustumType.AccurateFrustum;
 
         /// <summary>
-        /// When true, collect intersecting triangle indices.
-        /// </summary>
-        public bool CollectIndices = false;
-
-        /// <summary>
         /// When true, measure processing time in seconds.
         /// </summary>
         public bool MeasureTime = false;
@@ -39,9 +33,9 @@ namespace Optim.FrustumIntersection
     public class IntersectionResult
     {
         /// <summary>
-        /// Indices of intersecting triangles when <see cref="IntersectionOptions.CollectIndices"/> is enabled.
+        /// True when the triangle at the corresponding index intersects the frustum.
         /// </summary>
-        public List<int> IntersectedIndices = new();
+        public bool[] Intersections;
 
         /// <summary>
         /// Processing time in seconds. Valid only when <see cref="IntersectionOptions.MeasureTime"/> is enabled.

--- a/Assets/FrustumIntersection/Scripts/GPUImplementation.cs
+++ b/Assets/FrustumIntersection/Scripts/GPUImplementation.cs
@@ -55,22 +55,9 @@ namespace Optim.FrustumIntersection
             var results = new int[triCount];
             rbuf.GetData(results);
 
-            if (options.CollectIndices)
-            {
-                for (int i = 0; i < triCount; ++i)
-                {
-                    if (results[i] != 0)
-                        result.IntersectedIndices.Add(i);
-                }
-            }
-            else
-            {
-                for (int i = 0; i < triCount; ++i)
-                {
-                    if (results[i] != 0)
-                        break;
-                }
-            }
+            result.Intersections = new bool[triCount];
+            for (int i = 0; i < triCount; ++i)
+                result.Intersections[i] = results[i] != 0;
 
             vbuf.Dispose();
             ibuf.Dispose();


### PR DESCRIPTION
## Summary
- change IntersectionOptions to remove `CollectIndices`
- return `bool[]` per triangle instead of intersected index list
- update CPU, Job System and GPU implementations to fill the boolean array

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849ba445d648332bbb069aea4572c12